### PR TITLE
explicit 2d and 3d line segment messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,11 @@ set(msg_files
   "msg/Transducer.msg"
   "msg/TransducerArray.msg"
   "msg/PoseEulerStamped.msg"
-  "msg/Line2D.msg"
-  "msg/Line2DArray.msg"
+  "msg/Point2D.msg"
+  "msg/LineSegment2D.msg"
+  "msg/LineSegment2DArray.msg"
+  "msg/LineSegment3D.msg"
+  "msg/LineSegment3DArray.msg"
   "msg/SonarInfo.msg"
 )
 

--- a/msg/Line2D.msg
+++ b/msg/Line2D.msg
@@ -1,7 +1,0 @@
-# Line2D.msg
-
-float64 rho # distance from origin [m]
-float64 theta # angle [rad], normal direction
-
-geometry_msgs/Point p0
-geometry_msgs/Point p1

--- a/msg/LineSegment2D.msg
+++ b/msg/LineSegment2D.msg
@@ -1,0 +1,9 @@
+# LineSegment2D.msg
+#
+# Finite 2D line segment in image (pixel) coordinates.
+# x, y are pixel coordinates (float, may be integer-valued).
+# Origin: top-left of image.
+# x increases right, y increases down.
+
+Point2D p0
+Point2D p1

--- a/msg/LineSegment2D.msg
+++ b/msg/LineSegment2D.msg
@@ -1,7 +1,6 @@
 # LineSegment2D.msg
 #
 # Finite 2D line segment in image (pixel) coordinates.
-# x, y are pixel coordinates (float, may be integer-valued).
 # Origin: top-left of image.
 # x increases right, y increases down.
 

--- a/msg/LineSegment2DArray.msg
+++ b/msg/LineSegment2DArray.msg
@@ -2,4 +2,4 @@
 
 std_msgs/Header header
 
-Line2D[] lines
+LineSegment2D[] lines

--- a/msg/LineSegment3D.msg
+++ b/msg/LineSegment3D.msg
@@ -1,0 +1,2 @@
+geometry_msgs/Point p0
+geometry_msgs/Point p1

--- a/msg/LineSegment3DArray.msg
+++ b/msg/LineSegment3DArray.msg
@@ -1,0 +1,5 @@
+# LineSegment3DArray.msg
+
+std_msgs/Header header
+
+LineSegment3D[] lines

--- a/msg/Point2D.msg
+++ b/msg/Point2D.msg
@@ -1,0 +1,2 @@
+float64 x
+float64 y


### PR DESCRIPTION
Point2D is already defined in ros humble vision_msgs, but the line segment types are not. I don't want to include a vision_msgs dependency just for that, hench the custom Point2D type. 

I also think it is better to separate the 2D and 3D line segment cases to be more explicit