### PR TITLE
msgs(gripper): trim unused state fields and action feedback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ set(action_files
   "action/LocateDock.action"
   "action/NavigateWaypoints.action"
   "action/GripperReferenceFilterWaypoint.action"
+  "action/GripperOpenLoopCommand.action"
   "action/VtfGuidance.action"
   "action/GuidanceWaypoint.action"
   "action/FilteredPose.action"

--- a/action/GripperOpenLoopCommand.action
+++ b/action/GripperOpenLoopCommand.action
@@ -1,0 +1,16 @@
+# Goal
+float64 roll_velocity
+float64 pinch_velocity
+float64 duration_seconds
+uint8 mode
+
+# Mode constraints (mirrors GripperWaypoint mode constants)
+uint8 ROLL_AND_PINCH = 0
+uint8 ONLY_ROLL = 1
+uint8 ONLY_PINCH = 2
+---
+# Result
+bool success
+---
+# Feedback
+float64 elapsed_seconds

--- a/action/GripperReferenceFilterWaypoint.action
+++ b/action/GripperReferenceFilterWaypoint.action
@@ -6,4 +6,3 @@ float64 convergence_threshold
 bool success
 ---
 # Feedback
-vortex_msgs/GripperReferenceFilter reference

--- a/msg/GripperReferenceFilter.msg
+++ b/msg/GripperReferenceFilter.msg
@@ -1,11 +1,2 @@
-# nu_d
-float64 roll 
+float64 roll
 float64 pinch
-
-# nu_d_dot
-float64 roll_dot
-float64 pinch_dot
-
-# nu_d_dotdot
-float64 roll_dotdot
-float64 pinch_dotdot

--- a/msg/GripperWaypoint.msg
+++ b/msg/GripperWaypoint.msg
@@ -1,10 +1,9 @@
-GripperReferenceFilter roll
-GripperReferenceFilter pinch
+float64 roll
+float64 pinch
 
-uint8 mode 
+uint8 mode
 
 # GripperWaypoint mode constraints
 uint8 ROLL_AND_PINCH = 0
 uint8 ONLY_ROLL = 1
 uint8 ONLY_PINCH = 2
-


### PR DESCRIPTION
Addresses two PR review comments on
gripper_guidance/src/gripper_reference_filter_ros.cpp:

  (jorgenfj): "Does the gripper reference message need to be 6d if we
  ever only use the first two dims?"
  GripperReferenceFilter trimmed from 6 floats (roll, pinch, roll_dot,
  pinch_dot, roll_dotdot, pinch_dotdot) to 2 floats (roll, pinch). The
  filter genuinely computes derivatives but no downstream consumer
  (controller translator, sim bridge, CAN interface) reads anything
  beyond .roll and .pinch.
  GripperWaypoint changed from nested GripperReferenceFilter roll/pinch
  (only .roll.roll and .pinch.pinch were ever read; the five derivative
  fields per axis were always sent as 0 and never read) to flat float64
  roll, float64 pinch.
  
  (jorgenfj): "Should remove feedback from the action definition
  and just publish to topic if anyone is interested"
  GripperReferenceFilterWaypoint.action: feedback section emptied. The
  filter already publishes its smoothed reference on the topic output;
  mirroring it as action feedback was redundant.